### PR TITLE
Feature/mtu chunk size

### DIFF
--- a/src-dfu/NrfDfuServer.cpp
+++ b/src-dfu/NrfDfuServer.cpp
@@ -150,7 +150,16 @@ void NrfDfuServer::manage_state() {
         case DATAFILE_WRITE_FILE:
             this->waiting_response = false;  // Device does not respond until checksum request
             this->calculate_crc(this->datafile_data.c_str(), this->datafile_data.length());
-            this->write_packet(this->datafile_data);  // send data file
+            this->data_mtu_chunks_remaing = this->datafile_data.length() / MTU_CHUNK;
+            this->data_mtu_extra_bytes = this->datafile_data.length() % MTU_CHUNK;
+            for (i = 0; i < this->data_mtu_chunks_remaing; i++) {
+                this->write_packet( std::string(&this->datafile_data.c_str()[this->datafile_data.length() + MTU_CHUNK * i], MTU_CHUNK));  // send data file
+                //std::cout << " MTU chunk " << MTU_CHUNK << std::endl;
+            }
+            if (this->data_mtu_extra_bytes) {
+                this->write_packet(std::string(&this->datafile_data.c_str()[this->datafile_data.length() + MTU_CHUNK * i], this->data_mtu_extra_bytes));  // send data file
+                //std::cout << " Last MTU chunk " << this->data_mtu_extra_bytes << std::endl;
+            }
             break;
 
         case DATAFILE_REQ_CHECKSUM:

--- a/src-dfu/NrfDfuServer.h
+++ b/src-dfu/NrfDfuServer.h
@@ -222,6 +222,10 @@ class NrfDfuServer {
     const std::string &datafile_data;
     const std::string &binfile_data;
 
+    // * Data file sending variables
+    uint32_t data_mtu_extra_bytes;
+    uint32_t data_mtu_chunks_remaing;
+
     // * Bin file sending variables
     uint32_t bin_bytes_written;   // Total bin_bytes_written
     uint32_t bin_bytes_to_write;  // Bytes to write on mtu cycle

--- a/src-dfu/NrfDfuServerTypes.h
+++ b/src-dfu/NrfDfuServerTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 
 #define NORDIC_SECURE_DFU_SERVICE "0000fe59-0000-1000-8000-00805f9b34fb"      // Service handle 0x000b
 #define NORDIC_DFU_CONTROL_POINT_CHAR "8ec90001-f315-4f60-9fb8-838830daea50"  // Handle 0x000F

--- a/src-dfu/NrfDfuServerTypes.h
+++ b/src-dfu/NrfDfuServerTypes.h
@@ -8,8 +8,9 @@
 #define NORDIC_DFU_PACKET_CHAR "8ec90002-f315-4f60-9fb8-838830daea50"         // Handle 0x000D
 
 #define FLASH_PAGE_SIZE 4096
-// TODO: MTU Size will depend on platform (MacOs -.-)
-#define MTU_CHUNK 244
+
+// TODO: MTU Size will depend on platform (MacOs -.-), 20 byte chunk is a safe bet to start with
+#define MTU_CHUNK 20
 
 #define RESPONSE_LEN_CHECKSUM 8
 #define RESPONSE_LEN_SELECT 12


### PR DESCRIPTION
Identified an issue with data file write if MTU_CHUNK is set smaller than data file size. In contract to the bin file, the data wile was written in one chunk. Also I think an MTU_CHUNK size of 20 as default is better suited since it will support more hardware out of the box, with minimal impact on performance.